### PR TITLE
Fix warning `import/no-anonymous-default-export`:

### DIFF
--- a/diag-upload-ui/src/goatUrl.ts
+++ b/diag-upload-ui/src/goatUrl.ts
@@ -1,1 +1,2 @@
-export default 'https://c.tenor.com/QiJZATyPvZ0AAAAd/goat-hello.gif'
+const goatUrl = 'https://c.tenor.com/QiJZATyPvZ0AAAAd/goat-hello.gif'
+export default goatUrl


### PR DESCRIPTION
```
  Assign literal to a variable before exporting as module default
```