### PR TITLE
Fix the compilation of diag-upload-api

### DIFF
--- a/diag-upload-api/tsconfig.json
+++ b/diag-upload-api/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "module": "CommonJS",
+    "rootDir": "./src", 
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+  },
+  "include": ["src/**/*.ts"], 
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
```
Compilation error in .../diag-upload-service/diag-upload-api/src/server.ts
[ERROR] Unable to compile TypeScript:
error TS5109: Option 'moduleResolution' must be set to
'NodeNext' (or left unspecified) when  option 'module' is set to 'NodeNext'.
```